### PR TITLE
ci: Add static analysis to workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 on: [push]
 jobs:
-  build:
+  build_analyze:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the repository
@@ -9,7 +9,11 @@ jobs:
         submodules: recursive
     - name: Install ARM compiler
       run: sudo apt install gcc-arm-none-eabi
+    - name: Install static analyzer
+      run: sudo apt install cppcheck
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build
     - name: Compile source
       run: cmake --build ${{github.workspace}}/build
+    - name: Static analysis
+      run: cmake --build ${{github.workspace}}/build --target analysis 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,20 @@ add_custom_command(TARGET ${PROJECT_NAME}.elf POST_BUILD
     COMMAND cp ${CMAKE_BINARY_DIR}/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json
 )
 
+# Static Analysis
+set(ALZ cppcheck)
+set(ALZ_TARGET ${CMAKE_SOURCE_DIR}/src/)
+set(ALZ_FLAGS --enable=all 
+              --error-exitcode=1 
+              --suppress=missingInclude 
+              -I ${CMAKE_SOURCE_DIR}/src/ 
+              -I ${CMAKE_SOURCE_DIR}/src/drivers/)
+
+add_custom_target(analysis
+  COMMAND ${ALZ} ${ALZ_FLAGS} ${ALZ_TARGET}
+  COMMENT "Performing static analysis"
+)
+
 # Flashing MCU
 set(PROG openocd)
 set(PROG_TARGET "target/stm32f4x.cfg")


### PR DESCRIPTION
The build_analyze job (prev. build) will analyze the source code using cppcheck. If any warning shows up the workflow is expected to fail.